### PR TITLE
Bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,14 +3,19 @@
   "description": "A tool designed to sanity check settings before running your node.js application.",
   "homepage": "https://github.com/adamyanalunas/sanity",
   "dependencies": {
-    "lodash": "0.10.x",
-    "colors": "0.6.x"
+    "colors": "0.6.x",
+    "lodash": "^4.13.1"
   },
   "devDependencies": {
     "jasmine-node": "1.7.x",
     "sinon": "1.7.x"
   },
-  "keywords": ["util", "functional", "server", "sanity"],
+  "keywords": [
+    "util",
+    "functional",
+    "server",
+    "sanity"
+  ],
   "author": "Adam Yanalunas <adam@yanalunas.com>",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "A tool designed to sanity check settings before running your node.js application.",
   "homepage": "https://github.com/adamyanalunas/sanity",
   "dependencies": {
-    "colors": "0.6.x",
+    "colors": "^1.1.2",
     "lodash": "^4.13.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,12 +10,7 @@
     "jasmine-node": "1.7.x",
     "sinon": "1.7.x"
   },
-  "keywords": [
-    "util",
-    "functional",
-    "server",
-    "sanity"
-  ],
+  "keywords": ["util", "functional", "server", "sanity"],
   "author": "Adam Yanalunas <adam@yanalunas.com>",
   "repository": {
     "type": "git",

--- a/sanity.js
+++ b/sanity.js
@@ -4,7 +4,7 @@ var assign = require('lodash/assign'),
     forEach = require('lodash/forEach'),
     isEmpty = require('lodash/isEmpty'),
     os = require('os'),
-    colors = require('colors');
+    colors = require('colors/safe');
 
 var sanity = {
   reporter: function(report) {
@@ -52,9 +52,9 @@ var sanity = {
 
     if(failures.length > 0) {
       var heading = 'ERROR: Required settings are not correct!',
-          errs = [(options.zazz ? heading.red : heading)];
+          errs = [(options.zazz ? colors.red(heading) : heading)];
       failures.forEach(function(failure) {
-        errs.push('  ' + (options.zazz ? failure.key.bold : failure.key) + ': ' + failure.value);
+        errs.push('  ' + (options.zazz ? colors.bold(failure.key) : failure.key) + ': ' + failure.value);
       });
 
       message = errs.join(os.EOL);

--- a/sanity.js
+++ b/sanity.js
@@ -1,6 +1,8 @@
 'use strict';
 
-var _ = require('lodash'),
+var assign = require('lodash/assign'),
+    forEach = require('lodash/forEach'),
+    isEmpty = require('lodash/isEmpty'),
     os = require('os'),
     colors = require('colors');
 
@@ -10,7 +12,7 @@ var sanity = {
   },
   matchers: {
     defined: function(value) {
-      return !_.isEmpty(value);
+      return !isEmpty(value);
     },
     truthy: function(value) {
       return !!value;
@@ -22,7 +24,7 @@ var sanity = {
   check: function(required, options) {
     var failures = [],
         message = '';
-        options = _.extend({
+        options = assign({
           gagged: false,
           goodBook: null,
           passiveAggressive: false,
@@ -74,7 +76,7 @@ var sanity = {
     }
   },
   preach: function(insights, audience) {
-    _.forEach(insights, function(commandment, word) {
+    forEach(insights, function(commandment, word) {
       audience[word] = commandment;
     });
 

--- a/test/sanity.spec.js
+++ b/test/sanity.spec.js
@@ -1,7 +1,8 @@
 var _ = require('lodash'),
+    colors = require('colors/safe'),
     sanity = require('../sanity').sanity,
     sinon = require('sinon'),
-    os = require('os');
+    EOL = require('os').EOL;
 
 describe('Matchers', function() {
   it('has all presets', function() {
@@ -20,7 +21,7 @@ describe('Sanity', function() {
       reporterStub = null,
       preachStub = null,
       exitStub = null,
-      headingMessage = 'ERROR: Required settings are not correct!'.red + os.EOL;
+      headingMessage = 'ERROR: Required settings are not correct!';
 
   beforeEach(function() {
     reporterStub = sinon.stub(sanity, 'reporter');
@@ -40,7 +41,7 @@ describe('Sanity', function() {
       sanity.check(['ROOFIES']);
 
       var actual = reporterStub.getCall(0).args[0],
-          expected = 'ERROR: Required settings are not correct!'.red + os.EOL + '  ' + 'ROOFIES'.bold + ': undefined';
+          expected = colors.red(headingMessage) + EOL + '  ' + colors.bold('ROOFIES') + ': undefined';
       expect(actual).toEqual(expected);
     });
 
@@ -48,7 +49,7 @@ describe('Sanity', function() {
       sanity.check(['BOREDOM'], {zazz: false});
 
       var actual = reporterStub.getCall(0).args[0],
-          expected = 'ERROR: Required settings are not correct!' + os.EOL + '  BOREDOM: undefined';
+          expected = headingMessage + EOL + '  BOREDOM: undefined';
       expect(actual).toEqual(expected);
     });
   });
@@ -64,7 +65,7 @@ describe('Sanity', function() {
       sanity.check(['SOUL', 'HEART']);
 
       expect(reporterStub.callCount).toBe(1);
-      expect(reporterStub.getCall(0).args).toEqual([headingMessage + '  ' + 'SOUL'.bold + ': undefined' + os.EOL + '  ' + 'HEART'.bold + ': undefined']);
+      expect(reporterStub.getCall(0).args).toEqual([colors.red(headingMessage) + EOL + '  ' + colors.bold('SOUL') + ': undefined' + EOL + '  ' + colors.bold('HEART') + ': undefined']);
       expect(exitStub.callCount).toBe(1);
       expect(exitStub.getCall(0).args).toEqual([1]);
     });
@@ -134,7 +135,7 @@ describe('Sanity', function() {
       sanity.check(['ZIM', 'GIR'], null, null, callback);
 
       expect(callback.callCount).toBe(1);
-      expect(callback.getCall(0).args).toEqual([headingMessage + '  ZIM: undefined' + os.EOL + '  GIR: undefined', ['ZIM', 'GIR']]);
+      expect(callback.getCall(0).args).toEqual([color.red(headingMessage) + EOL + '  ZIM: undefined' + EOL + '  GIR: undefined', ['ZIM', 'GIR']]);
       expect(exitStub.callCount).toBe(0);
     });
   });
@@ -153,7 +154,7 @@ describe('Sanity', function() {
       sanity.check(['HOWARD_HUGHES'], {passiveAggressive: true});
 
       expect(reporterStub.callCount).toBe(1);
-      expect(reporterStub.getCall(0).args).toEqual([headingMessage + '  HOWARD_HUGHES: undefined']);
+      expect(reporterStub.getCall(0).args).toEqual([color.red(headingMessage) + EOL + '  HOWARD_HUGHES: undefined']);
       expect(exitStub.callCount).toBe(0);
     });
 


### PR DESCRIPTION
I've noticed when installing node dependencies that one of the dependencies was using an out-of-date version of `lodash`.  This PR bumps `sanity` to use a modern version of `lodash`.

**Changes**
- Bumps the core `lodash` dependency to latest since `0.x` is no longer supported
- Use references to individual `lodash` functions instead of pulling in the entire library into memory
- Bumps `colors` to the latest version, using `colors/safe` to not extend the base String class
- Updates unit tests to handle the above changes
